### PR TITLE
Add Prediction Inside card with placeholder graph

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,6 +17,9 @@
             <PredictionDetails ref="predictionDetailsRef" />
           </div>
           <div class="card">
+            <PredictionInside :plotUrl="predictionPlotUrl" />
+          </div>
+          <div class="card">
             <PredictionTable />
           </div>
         </div>
@@ -71,6 +74,7 @@ import Header from './components/Header.vue'
 import FetchButton from './components/FetchButton.vue'
 import DataChecker from './components/DataChecker.vue'
 import PredictionDetails from './components/PredictionDetails.vue'
+import PredictionInside from './components/PredictionInside.vue'
 import Modal from './components/Modal.vue'
 import ConnectionStatus from './components/ConnectionStatus.vue'
 import FetchLogsModal from './components/FetchLogsModal.vue'
@@ -79,11 +83,13 @@ import FetchLogsModal from './components/FetchLogsModal.vue'
 const showModal = ref(false)
 const modalMessage = ref('Running prediction...')
 const predictionDetailsRef = ref(null)
+const predictionPlotUrl = ref('')
 
 const triggerPrediction = async () => {
   showModal.value = true
   modalMessage.value = 'Running prediction...'
-  await predictionDetailsRef.value?.updatePrediction()
+  const result = await predictionDetailsRef.value?.updatePrediction()
+  predictionPlotUrl.value = result?.plotUrl || ''
   showModal.value = false
 }
 

--- a/frontend/src/components/PredictionDetails.vue
+++ b/frontend/src/components/PredictionDetails.vue
@@ -2,7 +2,6 @@
   <div>
     <h2>Prediction Details</h2>
     <p>Predicted % change in 10 days: <strong>{{ prediction.toFixed(2) }}%</strong></p>
-    <img :src="plotUrl" alt="Prediction scatter plot" v-if="plotUrl" />
   </div>
 </template>
 
@@ -20,13 +19,14 @@ async function updatePrediction() {
     prediction.value = 0
     plotUrl.value = ''
     alert(`Prediction failed: ${data.error}`)
-    return
+    return { plotUrl: '' }
   }
     
   prediction.value = data.prediction
   plotUrl.value = `data:image/png;base64,${data.plot_base64}`
+  return { plotUrl: plotUrl.value }
 }
 
 // allow this to be triggered externally
-defineExpose({ updatePrediction })
+defineExpose({ updatePrediction, plotUrl })
 </script>

--- a/frontend/src/components/PredictionInside.vue
+++ b/frontend/src/components/PredictionInside.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <h2>Prediction Inside</h2>
+    <img v-if="plotUrl" :src="plotUrl" alt="Prediction plot" />
+    <div v-else class="placeholder"></div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  plotUrl: {
+    type: String,
+    default: ''
+  }
+})
+</script>
+
+<style scoped>
+.placeholder {
+  width: 100%;
+  height: 300px;
+  background-color: #f3f3f3;
+  border: 1px dashed #ccc;
+}
+</style>


### PR DESCRIPTION
## Summary
- add new `PredictionInside` component for displaying prediction plots
- expose plot URL from `PredictionDetails` and return it from `updatePrediction`
- wire up new card in `App.vue` that shows a blank placeholder before any prediction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6854081a9fd0832985a70146e6be86d1