### PR TITLE
Update prediction details card

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,7 +17,13 @@
             <PredictionDetails ref="predictionDetailsRef" />
           </div>
           <div class="card">
-            <PredictionInside :plotUrl="predictionPlotUrl" />
+            <PredictionInside
+              :plotUrl="predictionPlotUrl"
+              :featureImportanceUrl="featureImportanceUrl"
+              :r2="r2"
+              :mae="mae"
+              :rmse="rmse"
+            />
           </div>
           <div class="card">
             <PredictionTable />
@@ -84,12 +90,20 @@ const showModal = ref(false)
 const modalMessage = ref('Running prediction...')
 const predictionDetailsRef = ref(null)
 const predictionPlotUrl = ref('')
+const featureImportanceUrl = ref('')
+const r2 = ref(0)
+const mae = ref(0)
+const rmse = ref(0)
 
 const triggerPrediction = async () => {
   showModal.value = true
   modalMessage.value = 'Running prediction...'
   const result = await predictionDetailsRef.value?.updatePrediction()
   predictionPlotUrl.value = result?.plotUrl || ''
+  featureImportanceUrl.value = result?.featureImportanceUrl || ''
+  r2.value = result?.r2 || 0
+  mae.value = result?.mae || 0
+  rmse.value = result?.rmse || 0
   showModal.value = false
 }
 

--- a/frontend/src/components/PredictionDetails.vue
+++ b/frontend/src/components/PredictionDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h2>Prediction Details</h2>
+    <h2>Prediction</h2>
     <p>Predicted % change in 10 days: <strong>{{ prediction.toFixed(2) }}%</strong></p>
   </div>
 </template>
@@ -10,6 +10,10 @@ import { ref } from 'vue'
 
 const prediction = ref(0)
 const plotUrl = ref('')
+const featureImportanceUrl = ref('')
+const r2 = ref(0)
+const mae = ref(0)
+const rmse = ref(0)
 
 async function updatePrediction() {
   const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/predict`)
@@ -18,15 +22,35 @@ async function updatePrediction() {
   if (data.error) {
     prediction.value = 0
     plotUrl.value = ''
+    featureImportanceUrl.value = ''
+    r2.value = 0
+    mae.value = 0
+    rmse.value = 0
     alert(`Prediction failed: ${data.error}`)
-    return { plotUrl: '' }
+    return {
+      plotUrl: '',
+      featureImportanceUrl: '',
+      r2: 0,
+      mae: 0,
+      rmse: 0
+    }
   }
-    
+
   prediction.value = data.prediction
   plotUrl.value = `data:image/png;base64,${data.plot_base64}`
-  return { plotUrl: plotUrl.value }
+  featureImportanceUrl.value = `data:image/png;base64,${data.importance_plot_base64}`
+  r2.value = data.r2
+  mae.value = data.mae
+  rmse.value = data.rmse
+  return {
+    plotUrl: plotUrl.value,
+    featureImportanceUrl: featureImportanceUrl.value,
+    r2: r2.value,
+    mae: mae.value,
+    rmse: rmse.value
+  }
 }
 
 // allow this to be triggered externally
-defineExpose({ updatePrediction, plotUrl })
+defineExpose({ updatePrediction, plotUrl, featureImportanceUrl, r2, mae, rmse })
 </script>

--- a/frontend/src/components/PredictionInside.vue
+++ b/frontend/src/components/PredictionInside.vue
@@ -1,8 +1,18 @@
 <template>
   <div>
-    <h2>Prediction Inside</h2>
-    <img v-if="plotUrl" :src="plotUrl" alt="Prediction plot" />
-    <div v-else class="placeholder"></div>
+    <h2>Prediction Details</h2>
+    <div v-if="plotUrl">
+      <h3>Prediction vs Actual</h3>
+      <img :src="plotUrl" alt="Prediction plot" />
+    </div>
+    <div v-if="featureImportanceUrl" class="metric">
+      <h3>Feature Importance</h3>
+      <img :src="featureImportanceUrl" alt="Feature importance plot" />
+    </div>
+    <p>R2 Score: {{ r2.toFixed(3) }}</p>
+    <p>MAE: {{ mae.toFixed(3) }}</p>
+    <p>RMSE: {{ rmse.toFixed(3) }}</p>
+    <div v-if="!plotUrl" class="placeholder"></div>
   </div>
 </template>
 
@@ -11,6 +21,22 @@ const props = defineProps({
   plotUrl: {
     type: String,
     default: ''
+  },
+  featureImportanceUrl: {
+    type: String,
+    default: ''
+  },
+  r2: {
+    type: Number,
+    default: 0
+  },
+  mae: {
+    type: Number,
+    default: 0
+  },
+  rmse: {
+    type: Number,
+    default: 0
   }
 })
 </script>
@@ -21,5 +47,8 @@ const props = defineProps({
   height: 300px;
   background-color: #f3f3f3;
   border: 1px dashed #ccc;
+}
+.metric {
+  margin-top: 1rem;
 }
 </style>

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,3 +8,14 @@ def test_train_and_predict_small_dataframe_raises_value_error():
     df = pd.DataFrame({'close': range(5)})
     with pytest.raises(ValueError, match=str(MIN_REQUIRED_ROWS)):
         train_and_predict(df)
+
+
+def test_train_and_predict_returns_metrics():
+    df = pd.DataFrame({'close': range(MIN_REQUIRED_ROWS + 10)})
+    result = train_and_predict(df)
+    assert 'prediction' in result
+    assert 'plot_base64' in result
+    assert 'r2' in result
+    assert 'mae' in result
+    assert 'rmse' in result
+    assert 'importance_plot_base64' in result


### PR DESCRIPTION
## Summary
- rename prediction card titles
- expose additional metrics in prediction response
- display metrics and feature importance plot in UI
- include tests for new metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68540b997100832991b7b7f7d229a505