### PR TITLE
Fix RMSE computation for newer sklearn

### DIFF
--- a/backend/model.py
+++ b/backend/model.py
@@ -151,7 +151,10 @@ def train_and_predict(df: pd.DataFrame):
     # === Model evaluation metrics ===
     r2 = r2_score(y_test, preds_test)
     mae = mean_absolute_error(y_test, preds_test)
-    rmse = mean_squared_error(y_test, preds_test, squared=False)
+    try:
+        rmse = mean_squared_error(y_test, preds_test, squared=False)
+    except TypeError:
+        rmse = np.sqrt(mean_squared_error(y_test, preds_test))
 
     # === Feature importance via permutation ===
     baseline = r2


### PR DESCRIPTION
## Summary
- handle new scikit-learn API when computing RMSE

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540dfb429c832982e73a584635ba73