### PR TITLE
Fix Fetch logs modal emit and cleanup fetch button

### DIFF
--- a/frontend/src/components/FetchButton.vue
+++ b/frontend/src/components/FetchButton.vue
@@ -19,7 +19,6 @@
     <FetchLogsModal
       v-if="showModal"
       @close="handleModalClose"
-      :onRefreshCount="refreshFetchCount"
     />
 
     <p v-if="message" class="status">{{ message }}</p>
@@ -27,7 +26,7 @@
 </template>
 
 <script setup>
-import { inject, ref, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import axios from 'axios'
 import FetchLogsModal from './FetchLogsModal.vue'
 
@@ -38,8 +37,6 @@ const fetchCount = ref(null)
 const showModal = ref(false)
 
 const emit = defineEmits(['fetch-complete'])
-
-const fetchWithLogs = inject('triggerFetchLogs')  // Not used anymore (replaced by modal toggle)
 
 const fetchLastDate = async () => {
   try {

--- a/frontend/src/components/FetchLogsModal.vue
+++ b/frontend/src/components/FetchLogsModal.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="modal">
       <div class="modal-content">
-        <button class="close-button" @click="$emit('close')">×</button>
+        <button class="close-button" @click="emit('close')">×</button>
         <h3>Fetch Logs</h3>
         <pre class="log-output">
           <code>{{ logs.join('') }}</code>
@@ -10,8 +10,10 @@
     </div>
   </template>
   
-  <script setup>
-  import { ref, onMounted } from 'vue'
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const emit = defineEmits(['close'])
   
   const logs = ref([])
   
@@ -37,7 +39,7 @@
     // Optional: auto-close after delay
     setTimeout(() => {
       // emit close only if modal is still visible
-      if (logs.value.length > 0) $emit('close')
+      if (logs.value.length > 0) emit('close')
     }, 3000)
   })
   </script>


### PR DESCRIPTION
## Summary
- fix FetchLogsModal emitter usage
- remove unused prop and injection in FetchButton

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68542c48b3248329be954f3f707ab3b5