### PR TITLE
Improve prediction error handling

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -94,12 +94,17 @@ const triggerPrediction = (models) => {
   showModal.value = true
 }
 
-function handlePredictionComplete(result) {
-  predictionDetailsRef.value?.setPredictionData(result || {})
-  const baseline = result?.baseline || {}
+function handlePredictionComplete({ results, error } = {}) {
+  if (error) {
+    // Keep modal open so the error message is visible
+    console.error('Prediction error:', error)
+    return
+  }
+  predictionDetailsRef.value?.setPredictionData(results || {})
+  const baseline = results?.baseline || {}
   predictionPlotUrl.value = baseline.plot_base64 ? `data:image/png;base64,${baseline.plot_base64}` : ''
   featureImportanceUrl.value = baseline.importance_plot_base64 ? `data:image/png;base64,${baseline.importance_plot_base64}` : ''
-  allMetrics.value = result || {}
+  allMetrics.value = results || {}
   showModal.value = false
 }
 provide('triggerPrediction', triggerPrediction)

--- a/frontend/src/components/PredictionProgress.vue
+++ b/frontend/src/components/PredictionProgress.vue
@@ -95,7 +95,7 @@ onMounted(async () => {
   } catch (err) {
     error.value = err.message
   }
-  emit('complete', results.value)
+  emit('complete', { results: results.value, error: error.value })
 })
 </script>
 


### PR DESCRIPTION
## Summary
- improve front-end logic for displaying streaming prediction errors
- keep prediction modal open when backend returns an error

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543af6de2083299b24281757a2af74