### PR TITLE
Improve prediction modal and handle missing persisted model

### DIFF
--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="modal-overlay">
     <div class="modal-content">
+      <button class="close-button" @click="$emit('close')">×</button>
       <slot />
     </div>
   </div>
@@ -27,5 +28,16 @@
   border-radius: 12px;
   text-align: center;
   width: 300px;
+  position: relative;
+}
+
+.close-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
## Summary
- gracefully handle a missing row when loading the persisted model
- keep the prediction modal open and allow manual close via an `x`
- abort running predictions when the modal is closed
- show backend errors returned from `/predict-stream`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551fbaa2cc8329a33689a5891b058e