### PR TITLE
Add root AGENTS file with setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+Repository Setup
+================
+
+Install backend dependencies with:
+
+```
+pip install -r backend/requirements.txt
+```
+
+Install frontend dependencies with:
+
+```
+npm install
+```
+
+Run tests from the repository root using:
+
+```
+pytest
+```
+
+The following environment variables must be provided, either in a `.env` file or through your environment configuration:
+
+- `ALPHA_VANTAGE_API_KEY`
+- `SUPABASE_URL`
+- `SUPABASE_KEY`
+


### PR DESCRIPTION
## Summary
- add AGENTS.md describing how to install dependencies, run tests and set env vars

## Testing
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6866ad2c85ac832d8f784169d781ba4f