### PR TITLE
Update prediction UI

### DIFF
--- a/frontend/src/components/PredictButton.vue
+++ b/frontend/src/components/PredictButton.vue
@@ -1,34 +1,73 @@
 <template>
   <div style="margin: 1rem 0;">
-    <div class="model-options">
-      <label v-for="opt in modelOptions" :key="opt.value">
-        <input type="checkbox" v-model="selectedModels" :value="opt.value" />
-        {{ opt.label }}
-      </label>
-    </div>
-    <button @click="predict">Predict</button>
+    <button class="open-btn" @click="openModal">Make a Prediction</button>
+
+    <Modal v-if="showModal" @close="closeModal">
+      <div class="model-options">
+        <label v-for="opt in modelOptions" :key="opt.value" class="model-option">
+          <input type="checkbox" v-model="selectedModels" :value="opt.value" />
+          <span class="label">{{ opt.label }}</span>
+          <div class="description">{{ opt.description }}</div>
+        </label>
+      </div>
+      <button class="predict-btn" @click="startPrediction">Predict</button>
+    </Modal>
   </div>
 </template>
 
 <script setup>
 import { inject, ref } from 'vue'
+import Modal from './Modal.vue'
+
 const triggerPrediction = inject('triggerPrediction')
 
 const modelOptions = [
-  { value: 'baseline', label: 'Baseline' },
-  { value: 'cross_validation', label: 'Cross Validation' },
-  { value: 'persist', label: 'Persisted' },
-  { value: 'grid_search', label: 'Grid Search' }
+  {
+    value: 'baseline',
+    label: 'Baseline',
+    description:
+      'Trains a lightweight neural network on recent data to forecast the next 10 days.',
+  },
+  {
+    value: 'cross_validation',
+    label: 'Cross Validation',
+    description:
+      'Evaluates the model with time-series cross validation and averages the metrics.',
+  },
+  {
+    value: 'persist',
+    label: 'Persisted',
+    description:
+      'Loads a previously saved model from Supabase if available and reuses it.',
+  },
+  {
+    value: 'grid_search',
+    label: 'Grid Search',
+    description:
+      'Runs a small grid search over network parameters and picks the best performer.',
+  },
 ]
-const selectedModels = ref(modelOptions.map(o => o.value))
 
-function predict() {
+const selectedModels = ref(modelOptions.map((o) => o.value))
+const showModal = ref(false)
+
+function openModal() {
+  showModal.value = true
+}
+
+function closeModal() {
+  showModal.value = false
+}
+
+function startPrediction() {
+  showModal.value = false
   triggerPrediction(selectedModels.value)
 }
 </script>
 
 <style scoped>
-button {
+.open-btn,
+.predict-btn {
   padding: 0.6rem 1.2rem;
   font-size: 1rem;
   background-color: #410093;
@@ -37,14 +76,30 @@ button {
   border-radius: 4px;
   cursor: pointer;
 }
-button:hover {
+.open-btn:hover,
+.predict-btn:hover {
   background-color: #5e2db7;
 }
 .model-options {
   margin-bottom: 0.5rem;
 }
-.model-options label {
-  margin-right: 0.5rem;
-  font-size: 0.9rem;
+.model-option {
+  display: block;
+  margin-bottom: 0.75rem;
+  text-align: left;
+}
+.label {
+  margin-left: 0.25rem;
+  font-weight: 600;
+}
+.description {
+  font-size: 0.85rem;
+  margin-left: 1.5rem;
+  margin-top: 0.25rem;
+  color: #555;
+}
+.predict-btn {
+  display: block;
+  margin: 0.5rem auto 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- open a model selection modal from the top-left card
- include check boxes and descriptions for each model
- trigger predictions once models are chosen

## Testing
- `pip install -r backend/requirements.txt`
- `cd frontend && npm install`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68679893127c832d8e3e8b45c64e66e5