### PR TITLE
Improve home page hero and how-it-works sections

### DIFF
--- a/frontend/src/components/Hero.vue
+++ b/frontend/src/components/Hero.vue
@@ -1,8 +1,11 @@
 <template>
   <section class="relative flex flex-col items-center justify-center text-center h-screen overflow-hidden bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white">
-    <div v-motion="{ initial: { opacity: 0, y: 20 }, enter: { opacity: 1, y: 0, transition: { duration: 0.6 } } }">
-      <h1 class="text-4xl md:text-6xl font-bold mb-4">AI-Powered Apple Stock Predictions</h1>
-      <p class="text-lg md:text-2xl mb-8">Pulling real data. Predicting near-future trends.</p>
+    <div class="absolute inset-0 pointer-events-none opacity-20 flex items-center justify-center">
+      <div class="text-7xl animate-bounce animated-apple">🍎</div>
+    </div>
+    <div v-motion="{ initial: { opacity: 0, y: 20 }, enter: { opacity: 1, y: 0, transition: { duration: 0.6 } } }" class="relative z-10">
+      <h1 class="typewriter text-4xl md:text-6xl font-bold mb-4">AI-Powered Apple Stock Price Predictions</h1>
+      <p class="text-lg md:text-2xl mb-8 fade-in">See what our deep learning model predicts for Apple's next move — based on real market data pulled live.</p>
       <div class="flex space-x-4 justify-center">
         <button @click="$emit('scrollToPredict')" class="px-6 py-3 rounded-lg bg-purple-600 hover:bg-purple-700">View Latest Prediction</button>
         <button @click="$emit('scrollToHow')" class="px-6 py-3 rounded-lg bg-gray-800 hover:bg-gray-700">How It Works</button>
@@ -16,4 +19,37 @@
 </script>
 
 <style scoped>
+.typewriter {
+  overflow: hidden;
+  border-right: 0.15em solid #fff;
+  white-space: nowrap;
+  animation: typing 3s steps(40, end), blink 0.75s step-end infinite;
+}
+
+.fade-in {
+  animation: fadeIn 2s ease forwards;
+}
+
+.animated-apple {
+  animation: float 4s ease-in-out infinite;
+}
+
+@keyframes typing {
+  from { width: 0 }
+  to { width: 100% }
+}
+
+@keyframes blink {
+  50% { border-color: transparent }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0 }
+  to { opacity: 1 }
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
 </style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -3,8 +3,21 @@
     <Hero @scrollToPredict="scrollToPredict" @scrollToHow="scrollToHow" />
 
     <section ref="howSection" class="py-20 bg-white text-center">
-      <h2 class="text-3xl font-bold mb-6">How It Works</h2>
-      <p class="max-w-2xl mx-auto text-lg">Animated walkthrough placeholder showing live API data, LSTM model and interactive chart.</p>
+      <h2 class="text-3xl font-bold mb-10">How It Works</h2>
+      <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-8">
+        <div v-motion="{ initial: { opacity: 0, y: 30 }, enter: { opacity: 1, y: 0, transition: { delay: 0.1 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
+          <div class="text-3xl mb-3">📡</div>
+          <p>Our backend fetches the latest Apple stock prices directly from the market.</p>
+        </div>
+        <div v-motion="{ initial: { opacity: 0, y: 30 }, enter: { opacity: 1, y: 0, transition: { delay: 0.3 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
+          <div class="text-3xl mb-3">🧠</div>
+          <p>We use a trained deep learning model to predict near-future prices.</p>
+        </div>
+        <div v-motion="{ initial: { opacity: 0, y: 30 }, enter: { opacity: 1, y: 0, transition: { delay: 0.5 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
+          <div class="text-3xl mb-3">📈</div>
+          <p>You get an interactive chart with our prediction and trend insights.</p>
+        </div>
+      </div>
     </section>
 
     <section ref="predictSection" class="py-20 bg-gray-50">


### PR DESCRIPTION
## Summary
- add animated typewriter text and floating apple icon in hero section
- build out the "How It Works" section with animated steps

## Testing
- `pip install -r backend/requirements.txt`
- `npm install` in frontend
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ebfc14de4832db80555ea236d691c