### PR TITLE
Fix nav scroll and update About info

### DIFF
--- a/frontend/src/components/About.vue
+++ b/frontend/src/components/About.vue
@@ -2,9 +2,9 @@
   <section ref="sectionRef" class="py-20 bg-gray-50 dark:bg-gray-800 text-center">
     <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">About the Project</h2>
     <img class="w-32 h-32 rounded-full mx-auto mb-4" :src="photoUrl" alt="Author photo" />
-    <p class="mb-4 text-gray-700 dark:text-gray-300">Built by Your Name</p>
+    <p class="mb-4 text-gray-700 dark:text-gray-300">Built by Thomas R McKinney</p>
     <div class="space-x-4">
-      <a class="text-purple-600 hover:underline" href="https://github.com/yourname" target="_blank" rel="noopener">GitHub</a>
+      <a class="text-purple-600 hover:underline" href="https://github.com/TRMcKinney" target="_blank" rel="noopener">GitHub</a>
       <a class="text-purple-600 hover:underline" href="mailto:contact@example.com">Contact</a>
     </div>
     <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
@@ -17,6 +17,7 @@
 import { ref } from 'vue'
 const photoUrl = 'https://via.placeholder.com/150'
 const sectionRef = ref(null)
+defineExpose({ sectionRef })
 </script>
 
 <style scoped>

--- a/frontend/src/components/WhyTrust.vue
+++ b/frontend/src/components/WhyTrust.vue
@@ -40,6 +40,7 @@ const chartOptions = {
 }
 const showInfo = ref(false)
 const sectionRef = ref(null)
+defineExpose({ sectionRef })
 </script>
 
 <style scoped>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -168,13 +168,20 @@ function scrollToPredict() {
   predictSection.value?.scrollIntoView({ behavior: 'smooth' })
 }
 
+function getSectionEl(sectionRef) {
+  const inst = sectionRef?.value
+  if (!inst) return null
+  return inst.sectionRef?.value ?? inst
+}
+
 function scrollToSection(name) {
   if (name === 'home') {
     window.scrollTo({ top: 0, behavior: 'smooth' })
     return
   }
   const map = { how: howSection, predict: predictSection, trust: trustSection, about: aboutSection }
-  map[name]?.value?.scrollIntoView({ behavior: 'smooth' })
+  const el = getSectionEl(map[name])
+  el?.scrollIntoView({ behavior: 'smooth' })
 }
 </script>
 


### PR DESCRIPTION
## Summary
- update About page author info
- expose `sectionRef` from About and WhyTrust components for parent access
- fix `scrollToSection` logic to properly use exposed DOM elements

## Testing
- `pip install -r backend/requirements.txt`
- `cd frontend && npm install`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686edd2ec750832d8458ad1c77dfc005