### PR TITLE
Add scroll animations and update navbar

### DIFF
--- a/frontend/src/components/About.vue
+++ b/frontend/src/components/About.vue
@@ -1,5 +1,5 @@
 <template>
-  <section ref="sectionRef" class="py-20 bg-gray-50 dark:bg-gray-800 text-center">
+  <section id="about" ref="sectionRef" class="py-20 bg-gray-50 dark:bg-gray-800 text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
     <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">About the Project</h2>
     <img class="w-32 h-32 rounded-full mx-auto mb-4" :src="photoUrl" alt="Author photo" />
     <p class="mb-4 text-gray-700 dark:text-gray-300">Built by Thomas R McKinney</p>

--- a/frontend/src/components/Hero.vue
+++ b/frontend/src/components/Hero.vue
@@ -1,21 +1,37 @@
 <template>
   <section class="relative flex flex-col items-center justify-center text-center h-screen overflow-hidden bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white">
-    <div class="absolute inset-0 pointer-events-none opacity-20 flex items-center justify-center">
+    <div class="absolute inset-0 pointer-events-none opacity-20 flex items-center justify-center" :style="appleStyle">
       <div class="text-7xl animate-bounce animated-apple">🍎</div>
     </div>
     <div v-motion="{ initial: { opacity: 0, y: 20 }, enter: { opacity: 1, y: 0, transition: { duration: 0.6 } } }" class="relative z-10">
       <h1 class="typewriter text-4xl md:text-6xl font-bold mb-4">AI-Powered Apple Stock Price Predictions</h1>
       <p class="text-lg md:text-2xl mb-8 fade-in">See what our deep learning model predicts for Apple's next move — based on real market data pulled live.</p>
-      <div class="flex space-x-4 justify-center">
-        <button @click="$emit('scrollToPredict')" class="px-6 py-3 rounded-lg bg-purple-600 hover:bg-purple-700">View Latest Prediction</button>
-        <button @click="$emit('scrollToHow')" class="px-6 py-3 rounded-lg bg-gray-800 hover:bg-gray-700">How It Works</button>
-      </div>
+      <!-- Navigation buttons moved to the banner -->
     </div>
   </section>
 </template>
 
 <script setup>
 // Emit events to scroll to sections
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+
+const scrollY = ref(0)
+
+function onScroll() {
+  scrollY.value = window.scrollY || 0
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll)
+})
+
+const appleStyle = computed(() => ({
+  transform: `translateY(${scrollY.value * -0.1}px)`
+}))
 </script>
 
 <style scoped>

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -1,11 +1,11 @@
 <template>
   <nav class="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-2 bg-white shadow dark:bg-gray-900 dark:text-white">
     <div class="flex space-x-4">
-      <a href="#" @click.prevent="scrollTo('home')" class="hover:underline">Home</a>
-      <a href="#" @click.prevent="scrollTo('how')" class="hover:underline">How It Works</a>
-      <a href="#" @click.prevent="scrollTo('predict')" class="hover:underline">Prediction</a>
-      <a href="#" @click.prevent="scrollTo('trust')" class="hover:underline">Why Trust It?</a>
-      <a href="#" @click.prevent="scrollTo('about')" class="hover:underline">About</a>
+      <a href="#home" @click.prevent="scrollTo('home')" class="hover:underline">Home</a>
+      <a href="#how" @click.prevent="scrollTo('how')" class="hover:underline">How It Works</a>
+      <a href="#predict" @click.prevent="scrollTo('predict')" class="hover:underline">Prediction</a>
+      <a href="#why-trust" @click.prevent="scrollTo('trust')" class="hover:underline">Why Trust It?</a>
+      <a href="#about" @click.prevent="scrollTo('about')" class="hover:underline">About</a>
     </div>
     <button @click="isDark = !isDark" class="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700">
       <span v-if="isDark">🌙</span>

--- a/frontend/src/components/WhyTrust.vue
+++ b/frontend/src/components/WhyTrust.vue
@@ -1,5 +1,5 @@
 <template>
-  <section ref="sectionRef" class="py-20 bg-white dark:bg-gray-900 text-center">
+  <section id="why-trust" ref="sectionRef" class="py-20 bg-white dark:bg-gray-900 text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
     <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">Why Trust It?</h2>
     <p class="max-w-3xl mx-auto mb-6 text-gray-700 dark:text-gray-300">
       Our predictions are powered by an LSTM neural network trained on years of Apple stock data.

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -3,25 +3,25 @@
     <NavBar :scrollToSection="scrollToSection" />
     <Hero @scrollToPredict="scrollToPredict" @scrollToHow="scrollToHow" />
 
-    <section ref="howSection" class="py-20 bg-white dark:bg-gray-900 text-center">
+    <section id="how" ref="howSection" class="py-20 bg-white dark:bg-gray-900 text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
       <h2 class="text-3xl font-bold mb-10">How It Works</h2>
       <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-8">
-        <div v-motion="{ initial: { opacity: 0, y: 30 }, enter: { opacity: 1, y: 0, transition: { delay: 0.1 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
+        <div v-motion="{ initial: { opacity: 0, y: 30 }, visibleOnce: { opacity: 1, y: 0, transition: { delay: 0.1 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
           <div class="text-3xl mb-3">📡</div>
           <p>Our backend fetches the latest Apple stock prices directly from the market.</p>
         </div>
-        <div v-motion="{ initial: { opacity: 0, y: 30 }, enter: { opacity: 1, y: 0, transition: { delay: 0.3 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
+        <div v-motion="{ initial: { opacity: 0, y: 30 }, visibleOnce: { opacity: 1, y: 0, transition: { delay: 0.3 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
           <div class="text-3xl mb-3">🧠</div>
           <p>We use a trained deep learning model to predict near-future prices.</p>
         </div>
-        <div v-motion="{ initial: { opacity: 0, y: 30 }, enter: { opacity: 1, y: 0, transition: { delay: 0.5 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
+        <div v-motion="{ initial: { opacity: 0, y: 30 }, visibleOnce: { opacity: 1, y: 0, transition: { delay: 0.5 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
           <div class="text-3xl mb-3">📈</div>
           <p>You get an interactive chart with our prediction and trend insights.</p>
         </div>
       </div>
     </section>
 
-    <section ref="predictSection" class="py-20 bg-gray-50 dark:bg-gray-800">
+    <section id="predict" ref="predictSection" class="py-20 bg-gray-50 dark:bg-gray-800" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
       <div class="container mx-auto px-4 space-y-6">
         <div class="flex flex-col md:flex-row md:space-x-6">
           <div class="flex-1 space-y-6">
@@ -56,9 +56,9 @@
       </div>
     </section>
 
-    <WhyTrust ref="trustSection" />
+    <WhyTrust />
 
-    <About ref="aboutSection" />
+    <About />
 
     <Modal v-if="showModal" @close="closePredictionModal">
       <PredictionProgress :models="selectedModels" :abortSignal="predictionAbortController?.signal" @complete="handlePredictionComplete" />
@@ -158,8 +158,6 @@ onMounted(() => {
 // === Smooth scroll helpers ===
 const howSection = ref(null)
 const predictSection = ref(null)
-const trustSection = ref(null)
-const aboutSection = ref(null)
 
 function scrollToHow() {
   howSection.value?.scrollIntoView({ behavior: 'smooth' })
@@ -168,19 +166,13 @@ function scrollToPredict() {
   predictSection.value?.scrollIntoView({ behavior: 'smooth' })
 }
 
-function getSectionEl(sectionRef) {
-  const inst = sectionRef?.value
-  if (!inst) return null
-  return inst.sectionRef?.value ?? inst
-}
-
 function scrollToSection(name) {
   if (name === 'home') {
     window.scrollTo({ top: 0, behavior: 'smooth' })
     return
   }
-  const map = { how: howSection, predict: predictSection, trust: trustSection, about: aboutSection }
-  const el = getSectionEl(map[name])
+  const map = { how: 'how', predict: 'predict', trust: 'why-trust', about: 'about' }
+  const el = document.getElementById(map[name])
   el?.scrollIntoView({ behavior: 'smooth' })
 }
 </script>


### PR DESCRIPTION
## Summary
- add parallax apple emoji effect in hero
- remove hero buttons now that navbar provides links
- fade in major sections on scroll and assign anchor IDs
- update navbar links to target new anchors
- simplify scrolling helper logic

## Testing
- `npm install --prefix frontend`
- `pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686edfd7446c832d99a46e1c010167f6