### PR TITLE
Switch to light design

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue</title>
+    <title>AI Stock Prediction</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vanta@latest/dist/vanta.net.min.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,6 @@ import Home from './views/Home.vue'
 
 <style>
 body {
-  @apply bg-gray-100 dark:bg-gray-900;
+  @apply bg-gray-100;
 }
 </style>

--- a/frontend/src/components/About.vue
+++ b/frontend/src/components/About.vue
@@ -1,13 +1,13 @@
 <template>
-  <section id="about" ref="sectionRef" class="py-20 bg-gray-50 dark:bg-gray-800 text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
-    <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">About the Project</h2>
+  <section id="about" ref="sectionRef" class="py-20 bg-gray-50 text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
+    <h2 class="text-3xl font-bold mb-6 text-gray-900">About the Project</h2>
     <img class="w-32 h-32 rounded-full mx-auto mb-4" :src="photoUrl" alt="Author photo" />
-    <p class="mb-4 text-gray-700 dark:text-gray-300">Built by Thomas R McKinney</p>
+    <p class="mb-4 text-gray-700">Built by Thomas R McKinney</p>
     <div class="space-x-4">
       <a class="text-purple-600 hover:underline" href="https://github.com/TRMcKinney" target="_blank" rel="noopener">GitHub</a>
       <a class="text-purple-600 hover:underline" href="mailto:contact@example.com">Contact</a>
     </div>
-    <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
+    <p class="mt-4 text-xs text-gray-500">
       Predictions are for educational purposes only and not financial advice.
     </p>
   </section>

--- a/frontend/src/components/Hero.vue
+++ b/frontend/src/components/Hero.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="relative flex flex-col items-center justify-center text-center h-screen overflow-hidden bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white">
+  <section ref="vantaRef" class="relative flex flex-col items-center justify-center text-center h-screen overflow-hidden bg-white text-gray-900">
     <div class="absolute inset-0 pointer-events-none opacity-20 flex items-center justify-center" :style="appleStyle">
       <div class="text-7xl animate-bounce animated-apple">🍎</div>
     </div>
@@ -15,6 +15,9 @@
 // Emit events to scroll to sections
 import { ref, onMounted, onUnmounted, computed } from 'vue'
 
+const vantaRef = ref(null)
+let vantaEffect = null
+
 const scrollY = ref(0)
 
 function onScroll() {
@@ -23,10 +26,24 @@ function onScroll() {
 
 onMounted(() => {
   window.addEventListener('scroll', onScroll)
+  if (window.VANTA?.NET) {
+    vantaEffect = window.VANTA.NET({
+      el: vantaRef.value,
+      mouseControls: true,
+      touchControls: true,
+      gyroControls: false,
+      color: 0xbbbbbb,
+      backgroundColor: 0xffffff,
+      points: 12.0,
+      maxDistance: 20.0,
+      spacing: 15.0
+    })
+  }
 })
 
 onUnmounted(() => {
   window.removeEventListener('scroll', onScroll)
+  if (vantaEffect) vantaEffect.destroy()
 })
 
 const appleStyle = computed(() => ({
@@ -37,7 +54,7 @@ const appleStyle = computed(() => ({
 <style scoped>
 .typewriter {
   overflow: hidden;
-  border-right: 0.15em solid #fff;
+  border-right: 0.15em solid #333;
   white-space: nowrap;
   animation: typing 3s steps(40, end), blink 0.75s step-end infinite;
 }

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-2 bg-white shadow dark:bg-gray-900 dark:text-white">
+  <nav class="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-2 bg-white shadow text-gray-900">
     <div class="flex space-x-4">
       <a href="#home" @click.prevent="scrollTo('home')" class="hover:underline">Home</a>
       <a href="#how" @click.prevent="scrollTo('how')" class="hover:underline">How It Works</a>
@@ -7,27 +7,11 @@
       <a href="#why-trust" @click.prevent="scrollTo('trust')" class="hover:underline">Why Trust It?</a>
       <a href="#about" @click.prevent="scrollTo('about')" class="hover:underline">About</a>
     </div>
-    <button @click="isDark = !isDark" class="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700">
-      <span v-if="isDark">🌙</span>
-      <span v-else>☀️</span>
-    </button>
   </nav>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
 const props = defineProps(['scrollToSection'])
-const isDark = ref(localStorage.getItem('theme') === 'dark')
-watch(isDark, val => {
-  const root = document.documentElement
-  if (val) {
-    root.classList.add('dark')
-    localStorage.setItem('theme', 'dark')
-  } else {
-    root.classList.remove('dark')
-    localStorage.setItem('theme', 'light')
-  }
-})
 function scrollTo(name) {
   props.scrollToSection?.(name)
 }

--- a/frontend/src/components/WhyTrust.vue
+++ b/frontend/src/components/WhyTrust.vue
@@ -1,18 +1,18 @@
 <template>
-  <section id="why-trust" ref="sectionRef" class="py-20 bg-white dark:bg-gray-900 text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
-    <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">Why Trust It?</h2>
-    <p class="max-w-3xl mx-auto mb-6 text-gray-700 dark:text-gray-300">
+  <section id="why-trust" ref="sectionRef" class="py-20 bg-white text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
+    <h2 class="text-3xl font-bold mb-6 text-gray-900">Why Trust It?</h2>
+    <p class="max-w-3xl mx-auto mb-6 text-gray-700">
       Our predictions are powered by an LSTM neural network trained on years of Apple stock data.
     </p>
     <div class="max-w-xl mx-auto h-64 mb-6">
       <Line :data="chartData" :options="chartOptions" />
     </div>
     <div class="max-w-xl mx-auto">
-      <button @click="showInfo = !showInfo" class="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700">
+      <button @click="showInfo = !showInfo" class="px-4 py-2 rounded bg-gray-200">
         {{ showInfo ? 'Hide' : 'View' }} model training info
       </button>
-      <div v-if="showInfo" class="mt-4 text-left p-4 bg-gray-100 dark:bg-gray-800 rounded">
-        <p class="text-sm text-gray-600 dark:text-gray-300">
+      <div v-if="showInfo" class="mt-4 text-left p-4 bg-gray-100 rounded">
+        <p class="text-sm text-gray-600">
           The model uses a multi-layer LSTM with dropout and is trained on daily prices from the past decade. Metrics such as MAE and RMSE are tracked during training.
         </p>
       </div>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,9 +1,9 @@
 <template>
-  <div id="home" class="font-sans text-gray-900 dark:text-gray-100">
+  <div id="home" class="font-sans text-gray-900">
     <NavBar :scrollToSection="scrollToSection" />
     <Hero @scrollToPredict="scrollToPredict" @scrollToHow="scrollToHow" />
 
-    <section id="how" ref="howSection" class="py-20 bg-white dark:bg-gray-900 text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
+    <section id="how" ref="howSection" class="py-20 bg-white text-center" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
       <h2 class="text-3xl font-bold mb-10">How It Works</h2>
       <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-8">
         <div v-motion="{ initial: { opacity: 0, y: 30 }, visibleOnce: { opacity: 1, y: 0, transition: { delay: 0.1 } } }" class="p-6 rounded-lg shadow-md bg-gray-50">
@@ -21,7 +21,7 @@
       </div>
     </section>
 
-    <section id="predict" ref="predictSection" class="py-20 bg-gray-50 dark:bg-gray-800" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
+    <section id="predict" ref="predictSection" class="py-20 bg-gray-50" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
       <div class="container mx-auto px-4 space-y-6">
         <div class="flex flex-col md:flex-row md:space-x-6">
           <div class="flex-1 space-y-6">


### PR DESCRIPTION
## Summary
- drop dark theme code from NavBar, pages and global styles
- keep Vanta background but use light colors

## Testing
- `pip install -r backend/requirements.txt`
- `npm install`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ee2306b04832d8be6093e2d2b63f1