### PR TITLE
Improve prediction section layout

### DIFF
--- a/frontend/src/components/PredictionDetails.vue
+++ b/frontend/src/components/PredictionDetails.vue
@@ -1,17 +1,17 @@
 <template>
   <div>
-    <h2>Prediction</h2>
-    <table>
-      <thead>
+    <h2 class="text-lg font-semibold mb-2">Prediction</h2>
+    <table class="min-w-full text-sm text-center border">
+      <thead class="bg-gray-100">
         <tr>
-          <th>Model</th>
-          <th>% Change (10d)</th>
+          <th class="py-2 px-3 border">Model</th>
+          <th class="py-2 px-3 border">% Change (10d)</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(m, name) in predictions" :key="name">
-          <td>{{ name }}</td>
-          <td>{{ m.prediction.toFixed(2) }}</td>
+        <tr v-for="(m, name) in predictions" :key="name" class="even:bg-gray-50">
+          <td class="py-2 px-3 border font-medium">{{ name }}</td>
+          <td class="py-2 px-3 border">{{ m.prediction.toFixed(2) }}</td>
         </tr>
       </tbody>
     </table>
@@ -60,14 +60,4 @@ function setPredictionData(data) {
 defineExpose({ updatePrediction, setPredictionData, plotUrl, featureImportanceUrl, predictions })
 </script>
 
-<style scoped>
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-th, td {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  text-align: center;
-}
-</style>
+<style scoped></style>

--- a/frontend/src/components/PredictionInside.vue
+++ b/frontend/src/components/PredictionInside.vue
@@ -1,29 +1,34 @@
 <template>
-  <div>
-    <h2>Prediction Details</h2>
-    <div v-if="plotUrl">
-      <h3>Prediction vs Actual</h3>
-      <img :src="plotUrl" alt="Prediction plot" />
+  <div class="space-y-6">
+    <h2 class="text-xl font-semibold">Prediction Details</h2>
+    <div v-if="plotUrl || featureImportanceUrl" class="grid md:grid-cols-2 gap-4">
+      <div v-if="plotUrl" class="bg-gray-50 p-4 rounded-lg shadow">
+        <h3 class="font-medium mb-2">Prediction vs Actual</h3>
+        <img :src="plotUrl" alt="Prediction plot" class="w-full" />
+      </div>
+      <div v-if="featureImportanceUrl" class="bg-gray-50 p-4 rounded-lg shadow">
+        <h3 class="font-medium mb-2">Feature Importance</h3>
+        <img :src="featureImportanceUrl" alt="Feature importance plot" class="w-full" />
+      </div>
     </div>
-    <div v-if="featureImportanceUrl" class="metric">
-      <h3>Feature Importance</h3>
-      <img :src="featureImportanceUrl" alt="Feature importance plot" />
-    </div>
-    <table v-if="Object.keys(metrics).length">
-      <thead>
+    <table
+      v-if="Object.keys(metrics).length"
+      class="w-full text-sm text-center border-collapse mt-4"
+    >
+      <thead class="bg-gray-100">
         <tr>
-          <th>Model</th>
-          <th>R2</th>
-          <th>MAE</th>
-          <th>RMSE</th>
+          <th class="py-2 px-3 border">Model</th>
+          <th class="py-2 px-3 border">R2</th>
+          <th class="py-2 px-3 border">MAE</th>
+          <th class="py-2 px-3 border">RMSE</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(m, name) in metrics" :key="name">
-          <td>{{ name }}</td>
-          <td>{{ m.r2.toFixed(3) }}</td>
-          <td>{{ m.mae.toFixed(3) }}</td>
-          <td>{{ m.rmse.toFixed(3) }}</td>
+        <tr v-for="(m, name) in metrics" :key="name" class="even:bg-gray-50">
+          <td class="py-2 px-3 border font-medium">{{ name }}</td>
+          <td class="py-2 px-3 border">{{ m.r2.toFixed(3) }}</td>
+          <td class="py-2 px-3 border">{{ m.mae.toFixed(3) }}</td>
+          <td class="py-2 px-3 border">{{ m.rmse.toFixed(3) }}</td>
         </tr>
       </tbody>
     </table>
@@ -50,22 +55,6 @@ const props = defineProps({
 
 <style scoped>
 .placeholder {
-  width: 100%;
-  height: 300px;
-  background-color: #f3f3f3;
-  border: 1px dashed #ccc;
-}
-.metric {
-  margin-top: 1rem;
-}
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 1rem;
-}
-th, td {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  text-align: center;
+  @apply w-full h-64 bg-gray-100 border border-dashed border-gray-300;
 }
 </style>

--- a/frontend/src/components/PredictionTable.vue
+++ b/frontend/src/components/PredictionTable.vue
@@ -1,30 +1,32 @@
 <template>
   <div>
-    <h2>Prediction History</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Date</th>
-          <th>Model</th>
-          <th>% Change</th>
-          <th>Predicted Price</th>
-          <th>Actual Price</th>
-          <th>Difference</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="row in history" :key="row.id">
-          <td>{{ row.date_of_prediction }}</td>
-          <td>{{ row.model_type }}</td>
-          <td>{{ row.prediction?.toFixed(2) }}</td>
-          <td>{{ row.predicted_price?.toFixed(2) }}</td>
-          <td>{{ row.actual_price != null ? row.actual_price.toFixed(2) : '-' }}</td>
-          <td>
-            {{ row.difference != null ? row.difference.toFixed(2) : '-' }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <h2 class="text-lg font-semibold mb-2">Prediction History</h2>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm text-center border">
+        <thead class="bg-gray-100">
+          <tr>
+            <th class="py-2 px-3 border">Date</th>
+            <th class="py-2 px-3 border">Model</th>
+            <th class="py-2 px-3 border">% Change</th>
+            <th class="py-2 px-3 border">Predicted Price</th>
+            <th class="py-2 px-3 border">Actual Price</th>
+            <th class="py-2 px-3 border">Difference</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in history" :key="row.id" class="even:bg-gray-50">
+            <td class="py-2 px-3 border">{{ row.date_of_prediction }}</td>
+            <td class="py-2 px-3 border">{{ row.model_type }}</td>
+            <td class="py-2 px-3 border">{{ row.prediction?.toFixed(2) }}</td>
+            <td class="py-2 px-3 border">{{ row.predicted_price?.toFixed(2) }}</td>
+            <td class="py-2 px-3 border">{{ row.actual_price != null ? row.actual_price.toFixed(2) : '-' }}</td>
+            <td class="py-2 px-3 border">
+              {{ row.difference != null ? row.difference.toFixed(2) : '-' }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
@@ -44,16 +46,4 @@ async function loadHistory() {
 
 onMounted(loadHistory)
 </script>
-
-<style scoped>
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 1rem;
-}
-th, td {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  text-align: center;
-}
-</style>
+<style scoped></style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -22,36 +22,22 @@
     </section>
 
     <section id="predict" ref="predictSection" class="py-20 bg-gray-50" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
-      <div class="container mx-auto px-4 space-y-6">
-        <div class="flex flex-col md:flex-row md:space-x-6">
-          <div class="flex-1 space-y-6">
-            <div class="card">
-              <PredictButton />
-            </div>
-            <div class="card">
-              <PredictionDetails ref="predictionDetailsRef" />
-            </div>
-            <div class="card">
-              <PredictionInside :plotUrl="predictionPlotUrl" :featureImportanceUrl="featureImportanceUrl" :metrics="allMetrics" />
-            </div>
-            <div class="card">
-              <PredictionTable />
-            </div>
+      <div class="container mx-auto px-4 space-y-8">
+        <div class="grid md:grid-cols-3 gap-6">
+          <div class="space-y-6">
+            <div class="card"><PredictButton /></div>
+            <div class="card"><FetchButton :fetchCount="fetchCount" /></div>
+            <div class="card"><DataChecker /></div>
+            <div class="card"><ConnectionStatus /></div>
           </div>
-          <div class="flex-1 space-y-6 mt-6 md:mt-0">
-            <div class="card">
-              <ConnectionStatus />
-            </div>
-            <div class="card">
-              <StockChart />
-            </div>
-            <div class="card">
-              <FetchButton :fetchCount="fetchCount" />
-            </div>
-            <div class="card">
-              <DataChecker />
-            </div>
+          <div class="md:col-span-2 space-y-6">
+            <div class="card"><StockChart /></div>
+            <div class="card"><PredictionDetails ref="predictionDetailsRef" /></div>
+            <div class="card"><PredictionInside :plotUrl="predictionPlotUrl" :featureImportanceUrl="featureImportanceUrl" :metrics="allMetrics" /></div>
           </div>
+        </div>
+        <div class="card mt-6">
+          <PredictionTable />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- redesign `PredictionInside.vue` with grid-based layout and Tailwind styles
- modernize styles for `PredictionDetails` and `PredictionTable`
- arrange the prediction tools and results in a tidy grid within `Home.vue`

## Testing
- `pip install -r backend/requirements.txt`
- `cd frontend && npm install`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686eeaf65cd0832d804547b5dc2f2f0f