### PR TITLE
Restructure prediction view into data and predict sections

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -3,7 +3,8 @@
     <div class="flex space-x-4">
       <a href="#home" @click.prevent="scrollTo('home')" class="hover:underline">Home</a>
       <a href="#how" @click.prevent="scrollTo('how')" class="hover:underline">How It Works</a>
-      <a href="#predict" @click.prevent="scrollTo('predict')" class="hover:underline">Prediction</a>
+      <a href="#data" @click.prevent="scrollTo('data')" class="hover:underline">Data</a>
+      <a href="#predict" @click.prevent="scrollTo('predict')" class="hover:underline">Predict</a>
       <a href="#why-trust" @click.prevent="scrollTo('trust')" class="hover:underline">Why Trust It?</a>
       <a href="#about" @click.prevent="scrollTo('about')" class="hover:underline">About</a>
     </div>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -21,24 +21,27 @@
       </div>
     </section>
 
-    <section id="predict" ref="predictSection" class="py-20 bg-gray-50" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
+    <section id="data" ref="dataSection" class="py-20 bg-gray-50" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
       <div class="container mx-auto px-4 space-y-8">
         <div class="grid md:grid-cols-3 gap-6">
           <div class="space-y-6">
-            <div class="card"><PredictButton /></div>
             <div class="card"><FetchButton :fetchCount="fetchCount" /></div>
             <div class="card"><DataChecker /></div>
             <div class="card"><ConnectionStatus /></div>
           </div>
-          <div class="md:col-span-2 space-y-6">
-            <div class="card"><StockChart /></div>
-            <div class="card"><PredictionDetails ref="predictionDetailsRef" /></div>
-            <div class="card"><PredictionInside :plotUrl="predictionPlotUrl" :featureImportanceUrl="featureImportanceUrl" :metrics="allMetrics" /></div>
+          <div class="md:col-span-2">
+            <div class="card h-full"><StockChart /></div>
           </div>
         </div>
-        <div class="card mt-6">
-          <PredictionTable />
-        </div>
+      </div>
+    </section>
+
+    <section id="predict" ref="predictSection" class="py-20 bg-gray-100" v-motion="{ initial: { opacity: 0, y: 50 }, visibleOnce: { opacity: 1, y: 0 } }">
+      <div class="container mx-auto px-4 space-y-6">
+        <div class="card"><PredictButton /></div>
+        <div class="card"><PredictionDetails ref="predictionDetailsRef" /></div>
+        <div class="card"><PredictionInside :plotUrl="predictionPlotUrl" :featureImportanceUrl="featureImportanceUrl" :metrics="allMetrics" /></div>
+        <div class="card"><PredictionTable /></div>
       </div>
     </section>
 
@@ -143,6 +146,7 @@ onMounted(() => {
 
 // === Smooth scroll helpers ===
 const howSection = ref(null)
+const dataSection = ref(null)
 const predictSection = ref(null)
 
 function scrollToHow() {
@@ -151,13 +155,16 @@ function scrollToHow() {
 function scrollToPredict() {
   predictSection.value?.scrollIntoView({ behavior: 'smooth' })
 }
+function scrollToData() {
+  dataSection.value?.scrollIntoView({ behavior: 'smooth' })
+}
 
 function scrollToSection(name) {
   if (name === 'home') {
     window.scrollTo({ top: 0, behavior: 'smooth' })
     return
   }
-  const map = { how: 'how', predict: 'predict', trust: 'why-trust', about: 'about' }
+  const map = { how: 'how', data: 'data', predict: 'predict', trust: 'why-trust', about: 'about' }
   const el = document.getElementById(map[name])
   el?.scrollIntoView({ behavior: 'smooth' })
 }


### PR DESCRIPTION
## Summary
- add Data navigation link and rename Prediction to Predict in NavBar
- split the prediction area into separate Data and Predict sections
- update scroll logic to handle the new Data section

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eef9a753c832db77fe6b01d31a99e