### PR TITLE
Fix FetchLogsModal closing behavior

### DIFF
--- a/frontend/src/components/FetchLogsModal.vue
+++ b/frontend/src/components/FetchLogsModal.vue
@@ -36,11 +36,6 @@ const emit = defineEmits(['close'])
       logs.value.push("\nError during fetch:\n" + err.message)
     }
   
-    // Optional: auto-close after delay
-    setTimeout(() => {
-      // emit close only if modal is still visible
-      if (logs.value.length > 0) emit('close')
-    }, 3000)
   })
   </script>
   


### PR DESCRIPTION
## Summary
- ensure FetchLogsModal stays open until user clicks X

## Testing
- `pip install -r backend/requirements.txt`
- `cd frontend && npm install`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6876291b380c832daafe8e8e033e6fcd