### PR TITLE
Add manual refresh for prediction history

### DIFF
--- a/backend/fetch_and_upload.py
+++ b/backend/fetch_and_upload.py
@@ -3,7 +3,6 @@ import requests
 from datetime import datetime
 from supabase import create_client
 from dotenv import load_dotenv
-from prediction_history import update_with_actual
 
 load_dotenv()
 
@@ -87,8 +86,6 @@ def upload_to_supabase(records):
             print(f"   Inserted: {row['timestamp']}")
         else:
             print(f"   Skipped duplicate: {row['timestamp']}")
-        # Update any prediction history entries expecting this date
-        update_with_actual(row["timestamp"], row["close"])
     return inserted_count
 
 def fetch_and_upload():

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,7 @@ import grid_search_model
 from fetch_and_upload import fetch_and_upload
 from fastapi.responses import StreamingResponse
 import json
-from prediction_history import insert_predictions
+from prediction_history import insert_predictions, refresh_missing_actuals
 
 # Load env vars
 load_dotenv()
@@ -109,6 +109,13 @@ def prediction_history():
         .execute()
     )
     return resp.data or []
+
+
+@app.post("/refresh-prediction-history")
+def refresh_prediction_history():
+    """Update prediction records with actual prices."""
+    updated = refresh_missing_actuals()
+    return {"updated": updated}
 
 @app.get("/stock-100")
 def stock_100():

--- a/frontend/src/components/PredictionTable.vue
+++ b/frontend/src/components/PredictionTable.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <h2 class="text-lg font-semibold mb-2">Prediction History</h2>
+    <div class="flex items-center mb-2">
+      <h2 class="text-lg font-semibold mr-4">Prediction History</h2>
+      <button class="refresh-btn" @click="refreshHistory">Update History</button>
+    </div>
     <div class="overflow-x-auto">
       <table class="min-w-full text-sm text-center border">
         <thead class="bg-gray-100">
@@ -33,6 +36,15 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 
+async function refreshHistory() {
+  try {
+    await fetch(`${import.meta.env.VITE_API_BASE_URL}/refresh-prediction-history`, { method: 'POST' })
+    await loadHistory()
+  } catch (err) {
+    console.error('Failed to refresh prediction history', err)
+  }
+}
+
 const history = ref([])
 
 async function loadHistory() {
@@ -46,4 +58,15 @@ async function loadHistory() {
 
 onMounted(loadHistory)
 </script>
-<style scoped></style>
+<style scoped>
+.refresh-btn {
+  padding: 0.4rem 0.8rem;
+  background-color: #2563eb;
+  color: white;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+.refresh-btn:hover {
+  background-color: #1e4db7;
+}
+</style>


### PR DESCRIPTION
## Summary
- remove automatic prediction history updates from `fetch_and_upload`
- add `refresh_missing_actuals` helper and new `/refresh-prediction-history` endpoint
- show a new **Update History** button in `PredictionTable` and call the new endpoint

## Testing
- `pip install -r backend/requirements.txt`
- `npm install` in `frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68776fc3b6c8832da9774b088aaaff99